### PR TITLE
fix: change from 'get_active_clients' to 'get_clients'

### DIFF
--- a/lua/larago/root.lua
+++ b/lua/larago/root.lua
@@ -8,7 +8,7 @@ function M.root_dir()
 	path = path ~= "" and vim.uv.fs_realpath(path) or nil
 	local roots = {}
 	if path then
-		for _, client in pairs(vim.lsp.get_active_clients({ bufnr = 0 })) do
+		for _, client in pairs(vim.lsp.get_clients({ bufnr = 0 })) do
 			local workspace = client.config.workspace_folders
 			local paths = workspace
 					and vim.tbl_map(function(ws)


### PR DESCRIPTION
On nvim 0.12 the method 'get_active_clients' will be deprecated, from now on the name of this method is 'get_clients'

ref: https://neovim.io/doc/user/deprecated.html#vim.lsp.get_active_clients()